### PR TITLE
Update README.md to include archive.org link to now gone web resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A flexible, open-source package to optimize a Linear Function Over the Set of Efficient Solutions for BOMILP
 
-Follow this link for the [Documentation](http://eng.usf.edu/~amsierra/documents/Documentation_OOESAlg.pdf).
+Follow this link for the [archived Documentation](https://web.archive.org/web/20221204220112/http://eng.usf.edu/~amsierra/documents/Documentation_OOESAlg.pdf).
 
 This is a criterion space search for optimizing a linear function over the set of efficient solutions of bi-objective mixed integer linear programs. This project is a julia v1.0.2 project which is written in Linux (Ubuntu).
 


### PR DESCRIPTION
The documentation seems to have been removed from the server. I added a link to an archived copy from archive.org
